### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -578,7 +578,7 @@ pub trait BorrowedResultExt<'a, T> {
     /// fn sum_file() -> whiteread::ReaderResult<i64> {
     ///     let mut reader = Reader::open("numbers.txt")?;
     ///     let mut s: i64 = 0;
-    ///     while let Some(x) = reader.continue_().none_on_too_short()? {
+    ///     while let Some(x) = reader.continue_::<i64>().none_on_too_short()? {
     ///         s += x
     ///     }
     ///     Ok(s)


### PR DESCRIPTION
If rust/pull/44287 lands  then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that this line will have a type ambiguity error, so this is a PR to preemptively prevent that.